### PR TITLE
Fix compile error for Wio Terminal

### DIFF
--- a/src/libb64/cdecode-Impl.h
+++ b/src/libb64/cdecode-Impl.h
@@ -12,7 +12,7 @@
 #include <core_esp8266_features.h>
 #endif
 
-#if defined(ESP32)
+#if defined(ESP32) || defined(WIO_TERMINAL)
 #define CORE_HAS_LIBB64
 #endif
 

--- a/src/libb64/cencode-Imp.h
+++ b/src/libb64/cencode-Imp.h
@@ -12,7 +12,7 @@
 #include <core_esp8266_features.h>
 #endif
 
-#if defined(ESP32)
+#if defined(ESP32) || defined(WIO_TERMINAL)
 #define CORE_HAS_LIBB64
 #endif
 

--- a/src/libb64/cencode-Impl.h
+++ b/src/libb64/cencode-Impl.h
@@ -12,7 +12,7 @@
 #include <core_esp8266_features.h>
 #endif
 
-#if defined(ESP32)
+#if defined(ESP32) || defined(WIO_TERMINAL)
 #define CORE_HAS_LIBB64
 #endif
 


### PR DESCRIPTION
Fix compile error for Wio Terminal due to libb64 conflicts:

![image](https://user-images.githubusercontent.com/47582872/100422090-95ce9880-30c4-11eb-923a-6b30fbfa1928.png)
